### PR TITLE
(MODULES-10815) Add Slack notification for daily test run

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -56,3 +56,51 @@ jobs:
 
       - name: Run unit tests
         run: bundle exec rake parallel_spec
+
+      - name: Send Slack notification
+        if: always()
+        shell: bash
+        env:
+          success: '#43c78a'
+          failure: '#ed5c5c'
+          cancelled: '#343434'
+        run: |
+          curl -X POST --data-urlencode \
+            "payload=\
+            {\
+              'channel': '#${{ secrets.SLACK_CHANNEL }}', \
+              'attachments': \
+              [\
+                {\
+                  'author_name': '${{ github.actor }}', \
+                  'author_link': 'http://github.com/${{ github.actor }}', \
+                  'author_icon': 'http://github.com/${{ github.actor }}.png?size=32', \
+                  'color': '${{ env[job.status] }}', \
+                  'fields': \
+                  [\
+                    {\
+                      'title': 'Git reference', \
+                      'value': '${{ github.ref }}', \
+                      'short': true, \
+                    },\
+                    {\
+                      'title': 'Event', \
+                      'value': '${{ github.event_name }}', \
+                      'short': true, \
+                    },\
+                    {\
+                      'title': 'Workflow', \
+                      'value': '<http://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>', \
+                    },\
+                    {\
+                      'title': ':ci_${{ job.status}}: *${{ github.repository }}*', \
+                      'value': 'The *${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}* run finished with status *${{ job.status }}*.', \
+                      'short': false, \
+                    },\
+                  ],\
+                  'footer': ':githublogo: Commit SHA: <http://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>', \
+                },\
+              ],\
+            }\
+            " \
+            ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+---
+name: 'Temporary daily Unit Tests run workaround'
+
+on:
+  schedule:
+    - cron: '0 4 * * 1-5'
+
+jobs:
+  daily_unit_tests_with_nightly_puppet_gem:
+    name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
+    strategy:
+      matrix:
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        puppet_version: [ 5, 6, 7 ]
+        include:
+          - puppet_version: 5
+            ruby: 2.4
+          - puppet_version: 6
+            ruby: 2.5
+          - puppet_version: 7
+            ruby: 2.7
+
+          - os: 'ubuntu-18.04'
+            os_type: 'Linux'
+            env_set_cmd: 'export '
+            gem_file: 'puppet-latest.gem'
+          - os: 'macos-10.15'
+            os_type: 'macOS'
+            env_set_cmd: 'export '
+            gem_file: 'puppet-latest-universal-darwin.gem'
+          - os: 'windows-2019'
+            os_type: 'Windows'
+            env_set_cmd: '$env:'
+            gem_file: 'puppet-latest-x64-mingw32.gem'
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install ruby version ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Install the latest nightly build of puppet${{ matrix.puppet_version }} gem
+        run: |
+          curl http://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem
+          gem install puppet.gem -N
+      - name: Prepare testing environment with bundler
+        run: |
+          bundle config set system 'true'
+          ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
+          bundle update --jobs 4 --retry 3
+      - name: Run unit tests
+        run: bundle exec rake parallel_spec


### PR DESCRIPTION
Starting with this commit, the daily `Unit Tests with nightly Puppet gem` run will now send the job result via a Slack notification. The Slack channel can be changed through the `SLACK_CHANNEL` from the GitHub Secrets of the repository.



Added a temporary commit to fix the scheduled workflow that should be removed afterwards.